### PR TITLE
Add replaces/conflicts on puppetdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
 
+* Add obsoletes/replaces/conflicts metadata with puppetdb and puppetdb-termini on the openvoxdb and openvoxdb-termini packages.
+
 ## 8.9.0
+
 * Initial openvoxdb release. Based on puppetdb 8.8.1. Supported on all platforms that puppetdb currently supports, but for all architectures rather than just x86_64.

--- a/project.clj
+++ b/project.clj
@@ -219,6 +219,7 @@
                        :repo-target "openvox8"
                        :nonfinal-repo-target "openvox8-nightly"
                        :logrotate-enabled false
+                       :replaces-pkgs [{:package "puppetdb" :version ""}]
                        :java-args ~(str "-Xmx192m "
                                         "-Djdk.tls.ephemeralDHKeySize=2048")}
                 :config-dir "ext/config/foss"}

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -60,7 +60,8 @@ namespace :vox do
       tmp = Dir.mktmpdir("ezbake")
       ezbake_dir = "#{tmp}/ezbake"
       run_command("git clone https://github.com/openvoxproject/ezbake #{ezbake_dir}")
-      Dir.chdir(ezbake_dir) { |_| run_command('git checkout main') }
+      ezbake_branch = ENV['EZBAKE_BRANCH'] || 'main'
+      Dir.chdir(ezbake_dir) { |_| run_command("git checkout #{ezbake_branch}") }
 
       puts "Starting container"
       teardown if container_exists


### PR DESCRIPTION
This adds the appropriate metadata (obsoletes/replaces/conflicts) on both RPM and DEB packages to allow installing openvoxdb over puppetdb and replace it successfully. The changes to ezbake will control this metdata for the termini package.