### PR TITLE
puppetdb-terminus: migrate to openvoxdb-terminus

### DIFF
--- a/contrib/gem/openvoxdb-terminus.gemspec
+++ b/contrib/gem/openvoxdb-terminus.gemspec
@@ -3,13 +3,13 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
-  gem.name          = "puppetdb-terminus"
+  gem.name          = "openvoxdb-terminus"
   gem.version       = "3.0.0"
-  gem.authors       = ["Puppet Labs"]
-  gem.email         = ["puppet@puppetlabs.com"]
-  gem.description   = "Puppet terminus files to connect to PuppetDB"
-  gem.summary       = "Connect Puppet to PuppetDB by setting up a terminus for PuppetDB"
-  gem.homepage      = "https://github.com/puppetlabs/puppetdb"
+  gem.authors       = ["Puppet Labs", "OpenVoxProject"]
+  gem.email         = ["openvox@voxpupuli.org"]
+  gem.description   = "Puppet terminus files to connect to OpenVoxDB"
+  gem.summary       = "Connect OpenVox to OpenVoxDB by setting up a terminus for OpenVoxDB"
+  gem.homepage      = "https://github.com/OpenVoxProject/openvoxdb"
   gem.license       = "Apache-2.0"
 
   gem.files         = Dir['LICENSE.txt', 'NOTICE.txt', 'README.md', 'puppet/lib/**/*', 'puppet/spec/**/*']
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency 'json'
-  gem.add_runtime_dependency 'puppet', ['>= 3.8.1', '<5.0']
+  gem.add_runtime_dependency 'openvox', '> 8.19', '< 9'
 end


### PR DESCRIPTION
Before we merge this: I think the file is currently not used. Perforce used to release it as a gem in... 2013! https://rubygems.org/gems/puppetdb-terminus

Since that it's just distributed as rpm/deb package. And the package doesn't contain the gemspec because.. the package is essentially a puppet module:
```
# dpkg-query -L openvoxdb-termini
/.
/opt
/opt/puppetlabs
/opt/puppetlabs/puppet
/opt/puppetlabs/puppet/lib
/opt/puppetlabs/puppet/lib/ruby
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/reports
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/reports/puppetdb.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/node
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/node/puppetdb.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/catalog
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/catalog/puppetdb.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/facts
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/facts/puppetdb.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/facts/puppetdb_apply.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/resource
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/resource/puppetdb.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/puppetdb.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/puppetdb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/puppetdb/command.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/puppetdb/config.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/puppetdb/http.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/puppetdb/atom.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/puppetdb/char_encoding.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/puppetdb/command_names.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/face
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/face/node
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/face/node/deactivate.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/face/node/status.rb
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/functions
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/functions/puppetdb_query.rb
/usr
/usr/share
/usr/share/doc
/usr/share/doc/openvoxdb-termini
/usr/share/doc/openvoxdb-termini/changelog.gz
```

So maybe we just delete the gemspec?