### PR TITLE
ezbake: Update 2.6.3-SNAPSHOT-openvox->3.0.1-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -283,7 +283,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "2.6.3-SNAPSHOT-openvox"]]}
+                      :plugins [[puppetlabs/lein-ezbake "3.0.1-SNAPSHOT"]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but


### PR DESCRIPTION
We pull in the main branch from
https://github.com/OpenVoxProject/ezbake, but in the project.cli we reference the version from
https://github.com/OpenVoxProject/ezbake/blob/main/project.clj#L1. That means we need to update our reference.