### PR TITLE
prep-debianish-root: Rely on bundler from CI

### DIFF
--- a/ext/bin/prep-debianish-root
+++ b/ext/bin/prep-debianish-root
@@ -71,7 +71,7 @@ flavor=$(ext/bin/flavor-from-spec "$spec")
 apt-get-update
 
 # moreutils for ts
-apt-get -y install bundler moreutils
+apt-get -y install moreutils
 
 case "$flavor" in
     core|ext|core+ext|int)


### PR DESCRIPTION
We want to ensure that we actually use the bundle we install via GHA.