### PR TITLE
ezbake: Introduce service-port variable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -197,6 +197,7 @@
   ;; the main namespace and start timeout need to be updated
   ;; there as well
   :lein-ezbake {:vars {:user "puppetdb"
+                       :service-port 8081
                        :group "puppetdb"
                        :build-type "foss"
                        :package-name "openvoxdb"


### PR DESCRIPTION
This enables ezbake to use the port in templates, e.g. rendering the systemd unit file. This is required to add a post start command to check if the tcp port is already reachable.