### PR TITLE
Allow override of ezbake version and fix ezbake ref passthrough

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,15 @@ on:
         description: 'A comma-separated list of rpm-based platforms to build for, excluding the architecture (e.g. el-9,amazon-2023). Do not include spaces. If not provided, will use the default list of platforms supported by OpenVox Server and DB.'
         required: false
         type: string
-
+      ezbake-ref:
+        description: |-
+          Branch/tag from ezbake that will be used for openvoxdb/server builds.
+        type: string
+        default: 'main'
+      ezbake-ver:
+        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version found in project.clj in this repo if not specified.'
+        type: string
+        required: false
 jobs:
   build:
     uses: 'openvoxproject/shared-actions/.github/workflows/build_ezbake.yml@main'
@@ -26,4 +34,6 @@ jobs:
       ref: ${{ inputs.ref }}
       deb_platform_list: ${{ inputs.deb_platform_list }}
       rpm_platform_list: ${{ inputs.rpm_platform_list }}
+      ezbake-ref: ${{ inputs.ezbake-ref }}
+      ezbake-ver: ${{ inputs.ezbake-ver }}
     secrets: inherit

--- a/project.clj
+++ b/project.clj
@@ -268,7 +268,7 @@
                                                ;; in the final package.
                                                [puppetlabs/puppetdb ~pdb-version]]
                       :name "puppetdb"
-                      :plugins [[puppetlabs/lein-ezbake "3.0.1-SNAPSHOT"]]}
+                      :plugins [[puppetlabs/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "3.0.1-SNAPSHOT")]]}
              :testutils {:source-paths ^:replace ["test"]
                          :resource-paths ^:replace []
                          ;; Something else may need adjustment, but

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -75,8 +75,9 @@ namespace :vox do
       run("cd /ezbake && lein install")
 
       puts "Building openvoxdb"
+      ezbake_version_var = ENV['EZBAKE_VERSION'] ? "EZBAKE_VERSION=#{ENV['EZBAKE_VERSION']}" : ''
       run("cd /code && rm -rf ruby && rm -rf output && bundle install --without test && lein install")
-      run("cd /code && COW=\"#{@debs}\" MOCK=\"#{@rpms}\" GEM_SOURCE='https://rubygems.org' EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true LEIN_PROFILES=ezbake lein with-profile user,ezbake,provided,internal ezbake local-build")
+      run("cd /code && COW=\"#{@debs}\" MOCK=\"#{@rpms}\" GEM_SOURCE='https://rubygems.org' #{ezbake_version_var} EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true LEIN_PROFILES=ezbake lein with-profile user,ezbake,provided,internal ezbake local-build")
       run_command("sudo chown -R $USER output", print_command: true)
       Dir.glob('output/**/*i386*').each { |f| FileUtils.rm_rf(f) }
       Dir.glob('output/puppetdb-*.tar.gz').each { |f| FileUtils.mv(f, f.sub('puppetdb','openvoxdb'))}


### PR DESCRIPTION
Because we want to build 8.11 with an old version of ezbake, and to ease local test/building in the future, this allows the ezbake version to be overridden via the EZBAKE_VERSION env var.

This also adds ezbake-ref and ezbake-var to the workflow, same as what openvox-server does.