### PR TITLE
Update report update condition to use report ID

### DIFF
--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1494,7 +1494,7 @@
                      ;; from the case where the incoming report needs partition(s) made for it.
                      (try
                        (jdbc/update! "resource_events" {:latest false} ["latest = true and report_id = ?" latest-report-id])
-                       (jdbc/update! "reports" {:latest false} ["latest = true and certname = ?" certname])
+                       (jdbc/update! "reports" {:latest false} ["latest = true and id = ?" latest-report-id])
                        (catch java.sql.BatchUpdateException e
                          ;; undefined table -- inheritance partitions, or declarative partitions w/ no children
                          ;; check constraint violation -- declarative partitions when row does not match child partitions


### PR DESCRIPTION
When multiple identical reports are submitted, there can be a race condition where a report is committed for that node during the time the second report is being processed and they are both trying to be set as the latest report, resulting in a duplicate report being stored. This causes any subsequent report submissions to fail for that node. This fixes the problem by using the latest-report-id calculated when the function is called, using its timestamp to decide if this report is in fact the latest report.

Fixes #16.