### PR TITLE
Fix transient failure in touch-parameters-test

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -308,7 +308,15 @@
 
   TODO: handle arrays and maps."
   class)
-(defmethod touch-parameter-value String [p] (.nextAscii (RandomStringUtils/secure) (count p)))
+(defmethod touch-parameter-value String [p]
+  (let [len (count p)]
+    (if (zero? len)
+      (.nextAscii (RandomStringUtils/secure) 1)  ; empty -> single char
+      (loop [attempts 5]
+        (let [new-val (.nextAscii (RandomStringUtils/secure) len)]
+          (if (or (not= new-val p) (zero? attempts))
+            new-val
+            (recur (dec attempts))))))))
 (defmethod touch-parameter-value Number [_] (rand-int 1000000))
 (defmethod touch-parameter-value Boolean [p] (not p))
 ;; Allow other types to pass through unmutated for now


### PR DESCRIPTION
touch-parameter-value for strings could return the identical string, causing touch-parameters to produce unchanged output. This happened when empty strings were selected or random generation happened to produce the same string (which is only plausible for _very_ short strings).

Fix by converting empty strings to single character so that the string is different and retrying up to 5 times for non-empty strings.