### PR TITLE
CI: comment download link to PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!--
+Thank you for contributing to this project!
+
+- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
+- Please check that here is no existing issue or PR that addresses your problem.
+- Our vulnerabilities reporting process is at https://voxpupuli.org/security/
+
+- The CI will build rpm and deb packages for openvoxdb. The packages will be
+stored in a zip archive and uploaded as GitHub artifacts.
+In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
+always named openvoxdb-$(git describe). The artifacts are available for 24
+hours.
+
+-->

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,8 @@ jobs:
   build:
     name: build openvoxdb
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
       - name: checkout repo
         uses: actions/checkout@v6
@@ -154,13 +156,23 @@ jobs:
           DESCRIBE=$(git describe --abbrev=9)
           echo "describe=${DESCRIBE//-/.}" >> $GITHUB_OUTPUT
       - name: Upload build artifacts
+        id: upload
         uses: actions/upload-artifact@v6
         with:
           name: openvoxdb-${{ steps.version.outputs.describe }}
           path: output/
           retention-days: 1 # quite low retention, because the artifacts are quite large
           overwrite: true # overwrite old artifacts if a PR runs again (artifacts are per PR * per project)
-
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v5
+        # Check if the event is not triggered by a fork
+        # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |-
+            The rpm/deb packages and the JAR file for openvoxdb are available in a zip archive:
+            ${{ steps.upload.outputs.artifact-url }}
 
   termini-rspec:
     name: openvoxdb-termini RSpec


### PR DESCRIPTION
if the source branch isn't from a fork, the comment should appear. CI should pass, without a comment, from forks. test from fork: https://github.com/OpenVoxProject/openvoxdb/pull/105