### PR TITLE
Fixes for test task

### DIFF
--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -35,14 +35,19 @@ namespace :vox do
       teardown if container_exists
       start_container(image)
 
+      # The tests make tons of temp dirs in the current working directory, and trying to do this
+      # inside the volume mount dir results in permissions issues. So we copy all of the code to /tmp/code
+      # and run from there. Not ideal, but we have to since it curls down pdbbox and we don't control that.
+      run("cp -r /code /tmp && chown -R root:root /tmp/code")
       run("apt update && apt install -y leiningen curl python3 procps")
-      run("cd /code && rm -rf ci/local && ext/bin/prep-debianish-root --for #{spec} --install ci/local")
+      run("cd /tmp/code && rm -rf ci/local && ext/bin/prep-debianish-root --for #{spec} --install ci/local")
       run('echo "postgres ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers')
       # There is a non-fatal error when running on an arm64 host, so we can ignore exit 255.
-      run("cd /code && ci/bin/prep-and-run-in local #{spec}", allowed_exit_codes: [0, 255])
-      run("cd /code && NO_ACCEPTANCE=true ci/bin/run #{spec}", 'postgres')
+      run("cd /tmp/code && ci/bin/prep-and-run-in local #{spec}", allowed_exit_codes: [0, 255])
+      run("chown -R postgres:postgres /tmp/code")
+      run("cd /tmp/code && NO_ACCEPTANCE=true ci/bin/run #{spec}", 'postgres')
     ensure
-      teardown
+      #teardown
     end
   end
 end


### PR DESCRIPTION
(I could have sworn this was working before with the previous PR, oops 😅 )

Most of the instances of mktemp in all the various test harnesses give it a template, which causes it to create the temp dir in the current working directory. When we're inside a volume mounted directory, this causes problems. We could mitigate some of this by adding the --tmpdir flag, but the tests curl down the pdbbox tool, which we do not control and uses the same mktemp strategy. So this copies all the code inside the container so we have full permissions on it and can assign permissions to the postgres user for running the tests.  We can't run tests as root because postgres flatly disallows running many things as root.

Also a tweak to vox:test to make defaulting the spec when not provided work correctly.