### PR TITLE
Add test summary for the end of lein test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -305,6 +305,7 @@
 
     :dev-settings {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]
                     :plugins [[jonase/eastwood "1.4.3"]]
+                    :injections [(require 'test-summary)]
                     :jvm-opts ~(conj pdb-jvm-opts "-XX:-OmitStackTraceInFastThrow")}
 
     :dev [:defaults :dev-settings]

--- a/test/test_summary.clj
+++ b/test/test_summary.clj
@@ -1,0 +1,38 @@
+(ns test-summary
+  (:require [clojure.test :as t]))
+
+(def ^:private failures (atom []))
+
+(defonce ^:private original-report-fail (get-method t/report :fail))
+(defonce ^:private original-report-error (get-method t/report :error))
+(defonce ^:private original-report-summary (get-method t/report :summary))
+
+(defmethod t/report :fail [m]
+  (swap! failures conj (assoc m
+                              :test-var (first t/*testing-vars*)
+                              :contexts t/*testing-contexts*))
+  (original-report-fail m))
+
+(defmethod t/report :error [m]
+  (swap! failures conj (assoc m
+                              :test-var (first t/*testing-vars*)
+                              :contexts t/*testing-contexts*))
+  (original-report-error m))
+
+(defmethod t/report :summary [m]
+  (original-report-summary m)
+  (when (seq @failures)
+    (println "\n\n========== FAILURE SUMMARY ==========\n")
+    (doseq [{:keys [type test-var message expected actual file line]} @failures]
+      (println (str (name type) ": "
+                    (when test-var
+                      (str (-> test-var meta :ns) "/" (-> test-var meta :name)))))
+      (when (and file line)
+        (println (str "  at " file ":" line)))
+      (when message
+        (println (str "  " message)))
+      (println (str "  expected: " (pr-str expected)))
+      (println (str "    actual: " (pr-str actual)))
+      (println))
+    (println "======================================\n"))
+  (reset! failures []))


### PR DESCRIPTION
The test suite generates quite a lot of errors that are actually expected and not test failures, so it's hard to pick out what the real failures were. This adds a wrapper that collects all of the real failures and prints them out at the end of the test run.

Sample output of failures:
```
Ran 685 tests containing 13534 assertions.
3 failures, 0 errors.


========== FAILURE SUMMARY ==========

fail: puppetlabs.puppetdb.http.index-test/index-queries
  at index_test.clj:79
  expected: (re-matches #"(?s)Json parse error at line 1, column 17:\n\n
                \[\"from\",\"foobar\"\n
                \s+\^\n\n
                Unexpected end-of-input: expected close marker for Array
                \(start marker at \[Source: .*; line: 1, column: 1\]\)" body)
    actual: (not (re-matches #"(?s)Json parse error at line 1, column 17:\n\n
                \[\"from\",\"foobar\"\n
                \s+\^\n\n
                Unexpected end-of-input: expected close marker for Array
                \(start marker at \[Source: .*; line: 1, column: 1\]\)" "Json parse error at line 1, column 17:\n\n[\"from\",\"foobar\"\n               ^\n\nUnexpected end-of-input: expected close marker for Array (start marker at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1])"))

fail: puppetlabs.puppetdb.http.index-test/index-queries
  at index_test.clj:79
  expected: (re-matches #"(?s)Json parse error at line 1, column 17:\n\n
                \[\"from\",\"foobar\"\n
                \s+\^\n\n
                Unexpected end-of-input: expected close marker for Array
                \(start marker at \[Source: .*; line: 1, column: 1\]\)" body)
    actual: (not (re-matches #"(?s)Json parse error at line 1, column 17:\n\n
                \[\"from\",\"foobar\"\n
                \s+\^\n\n
                Unexpected end-of-input: expected close marker for Array
                \(start marker at \[Source: .*; line: 1, column: 1\]\)" "Json parse error at line 1, column 17:\n\n[\"from\",\"foobar\"\n               ^\n\nUnexpected end-of-input: expected close marker for Array (start marker at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1])"))

fail: puppetlabs.puppetdb.http.reports-test/query-report-with-malformed-json
  at reports_test.clj:222
  expected: (= (str "Json parse error at line 1, column 5:\n\n" "[\"=\"\n" "   ^\n\n" "Unexpected end-of-input: expected close marker for Array " "(start marker at [Source: (StringReader); line: 1, column: 1])") body)
    actual: (not (= "Json parse error at line 1, column 5:\n\n[\"=\"\n   ^\n\nUnexpected end-of-input: expected close marker for Array (start marker at [Source: (StringReader); line: 1, column: 1])" "Json parse error at line 1, column 5:\n\n[\"=\"\n   ^\n\nUnexpected end-of-input: expected close marker for Array (start marker at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1])"))

======================================

Subprocess failed (exit code: 1)
Error encountered performing task 'test' with profile(s): 'defaults,dev-settings'
Subprocess failed (exit code: 1)
++ /tmp/code/ext/bin/pdbbox-env pg_ctl stop
waiting for server to shut down.... done
server stopped
+ rm -rf /tmp/code/core-test-jQ5ZR2/box
+ rm -rf /tmp/code/core-test-jQ5ZR2
Command failed! Command: docker exec -u postgres openvoxdb-test /bin/bash --login -c 'cd /tmp/code && NO_ACCEPTANCE=true ci/bin/run core+ext/openjdk17/pg-17', Exit code: 1
```