### PR TITLE
Fixes for jackson output changes

### DIFF
--- a/test/puppetlabs/puppetdb/http/index_test.clj
+++ b/test/puppetlabs/puppetdb/http/index_test.clj
@@ -77,11 +77,12 @@
       ;; Ensure we parse anything that looks like AST/JSON as JSON not PQL
       (let [{:keys [status body headers]} (query-response method endpoint "[\"from\",\"foobar\"")]
         (is (re-matches
-              #"(?s)Json parse error at line 1, column 17:\n\n
-                \[\"from\",\"foobar\"\n
-                \s+\^\n\n
-                Unexpected end-of-input: expected close marker for Array
-                \(start marker at \[Source: .*; line: 1, column: 1\]\)"
+              (re-pattern
+                (str "(?s)Json parse error at line 1, column 17:\\n\\n"
+                    "\\[\"from\",\"foobar\"\\n"
+                    "\\s+\\^\\n\\n"
+                    "Unexpected end-of-input: expected close marker for Array "
+                    "\\(start marker at \\[Source: .*; line: 1, column: 1\\]\\)"))
               body))
         (are-error-response-headers headers)
         (is (= HttpURLConnection/HTTP_BAD_REQUEST status)))

--- a/test/puppetlabs/puppetdb/http/reports_test.clj
+++ b/test/puppetlabs/puppetdb/http/reports_test.clj
@@ -219,11 +219,14 @@
   (let [{:keys [status body]} (query-response :get "/v4/reports" "[\"=\"")]
     (testing "malformed json queries don't return status 500 responses"
       (is (= 400 status))
-      (is (= (str "Json parse error at line 1, column 5:\n\n"
-                  "[\"=\"\n"
-                  "   ^\n\n"
+      (is (re-matches
+            (re-pattern
+              (str "Json parse error at line 1, column 5:\\n\\n"
+                  "\\[\"=\"\\n"
+                  "   \\^\\n\\n"
                   "Unexpected end-of-input: expected close marker for Array "
-                  "(start marker at [Source: (StringReader); line: 1, column: 1])") body)))))
+                  "\\(start marker at \\[Source: .*; line: 1, column: 1\\]\\)"))
+            body)))))
 
 (deftest-http-app query-report-data
   [[_version field] [[:v4 :logs] [:v4 :metrics]]


### PR DESCRIPTION
The original change for the index test wasn't quite right as it did not escape things properly. This also adds on a fix for the reports test for the same change to jackson output.