### PR TITLE
Downgrade ring-core to version 1.14.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -197,7 +197,7 @@
                          [prismatic/schema "1.4.1"]
                          [riddley "0.2.0"]
                          [ring/ring-codec "1.3.0"]
-                         [ring/ring-core "1.15.3"]
+                         [ring/ring-core "1.14.2"]
                          [ring/ring-mock "0.6.2"]
                          [robert/hooke "1.3.0"]
                          [timofreiberg/bultitude "0.3.1"]


### PR DESCRIPTION
Due to the performance regression found in https://github.com/OpenVoxProject/openvox-server/pull/184, we are avoiding 1.15.x for now until we have a fix.