### PR TITLE
Add FIPS release job and update project version machinery

### DIFF
--- a/.github/workflows/build_fips.yml
+++ b/.github/workflows/build_fips.yml
@@ -1,0 +1,34 @@
+---
+name: Build openvoxdb - FIPS platforms
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag to build'
+        required: true
+      rpm_platform_list:
+        description: 'A comma-separated list of rpm-based platforms to build for, excluding the architecture (e.g. redhatfips-8,redhatfips-9). Do not include spaces. If not provided, will use the default list of FIPS platforms supported by OpenVox Server and DB.'
+        required: false
+        type: string
+      ezbake-ref:
+        description: 'Branch/tag from ezbake that will be used for openvoxdb/server builds.'
+        type: string
+        default: 'main'
+      ezbake-ver:
+        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version found in project.clj in this repo if not specified.'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: 'openvoxproject/shared-actions/.github/workflows/build_ezbake_fips.yml@main'
+    with:
+      ref: ${{ inputs.ref }}
+      rpm_platform_list: ${{ inputs.rpm_platform_list }}
+      ezbake-ref: ${{ inputs.ezbake-ref }}
+      ezbake-ver: ${{ inputs.ezbake-ver }}
+    secrets: inherit

--- a/release_scripts/sync_ezbake_dep.rb
+++ b/release_scripts/sync_ezbake_dep.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+file = ARGV[0] || "project.clj"
+text = File.read(file)
+
+v = text[/^\(defproject\s+\S+\s+"([^"]+)"/m, 1]
+abort("Couldn't find defproject version string in #{file}") unless v
+
+re = /\[org\.openvoxproject\/puppetdb\s+"[^"]+"\]/
+abort("Couldn't find literal [org.openvoxproject/puppetdb \"...\"] in #{file}") unless text.match?(re)
+
+text.gsub!(re, %[[org.openvoxproject/puppetdb "#{v}"]])
+File.write(file, text)
+
+puts "Synced ezbake dep to #{v}"


### PR DESCRIPTION
In order to use 'lein release' and it's automated method of bumping versions, the version string has to directly be in the defproject declaration. We could write our own version bumping logic, but we'd have to recreate what 'lein change version' does.

Instead, this adds a small script to sync the version defined in ezbake defs to what is in defproject. This allows us to use the same shared release GitHub action as all the other projects, and still keep this line in sync.

The lein-release plugin was also removed. It seems this was used to create a tarball of the repo, but we don't use that for anything anymore and it shadows the real lein release command.
