### PR TITLE
Lookup version from openvox group namespace

### DIFF
--- a/src/puppetlabs/puppetdb/meta/version.clj
+++ b/src/puppetlabs/puppetdb/meta/version.clj
@@ -11,4 +11,4 @@
   "Get the version number of this PuppetDB installation."
   []
   {:post [(string? %)]}
-  (version/get-version "puppetlabs" "puppetdb"))
+  (version/get-version "org.openvoxproject" "puppetdb"))


### PR DESCRIPTION
When running in dev via leiningen, this could look up the version from just "puppetdb", but in the uberjar it needs to lookup the full artifact name so it was returning "".

Fixes OpenVoxProject/openvoxdb#183

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
