### PR TITLE
Downgrade ring-core version from 1.15.3 to 1.14.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -198,7 +198,7 @@
                          [prismatic/schema "1.4.1"]
                          [riddley "0.2.2"]
                          [ring/ring-codec "1.3.0"]
-                         [ring/ring-core "1.15.3"]
+                         [ring/ring-core "1.14.2"]
                          [ring/ring-mock "0.6.2"]
                          [robert/hooke "1.3.0"]
                          [timofreiberg/bultitude "0.3.1"]


### PR DESCRIPTION
Downgrade ring-core version to avoid performance issue (see #197).