### PR TITLE
Depend on latest openvox-agent packages

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -1,7 +1,7 @@
 ezbake: {
   pe: {}
   foss: {
-    redhat: { dependencies: ["openvox-agent >= 8.21.0"],
+    redhat: { dependencies: ["openvox-agent >= 8.26.2"],
               preinst:  [],
               postinst: [
                   "/opt/puppetlabs/server/bin/puppetdb config-migration",
@@ -32,7 +32,7 @@ ezbake: {
                   " fi)"
               ]
             },
-    debian: { dependencies: ["openvox-agent (>= 8.21.0)"],
+    debian: { dependencies: ["openvox-agent (>= 8.26.2)"],
               preinst:  [],
               postinst: ["/opt/puppetlabs/server/bin/puppetdb config-migration",
                          "/opt/puppetlabs/server/bin/puppetdb ssl-setup"] }


### PR DESCRIPTION
In case people only upgrade their openvox-server package, this ensures that they also get the latest agent. This is important because it's the only combination we test against.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
