### PR TITLE
fix: include tarballs in snapshot artifact upload by matching on version

### DIFF
--- a/rakelib/upload.rake
+++ b/rakelib/upload.rake
@@ -38,6 +38,16 @@ namespace :vox do
       glob += "#{os}*"
     end
     files = Dir.glob(glob)
+
+    # Tarballs use a different version format than RPM/DEB packages.
+    # ezbake generates the tarball name from the git tag (e.g. 8.13.0.SNAPSHOT.2026...)
+    # while RPM/DEB use the version-release format (e.g. 8.13.0-0.1SNAPSHOT.2026...).
+    # Match tarballs separately by version to cover both formats.
+    unless os
+      tarball_files = Dir.glob("#{__dir__}/../output/openvoxdb-#{version}*.tar.gz")
+      files = (files + tarball_files).uniq
+    end
+
     abort 'No files for the given tag found in the output directory.' if files.empty?
 
     path = "s3://#{bucket}/#{component}/#{tag}"


### PR DESCRIPTION
The `vox:upload` rake task fails to upload tarballs for snapshot builds because the tarball filename uses a different version format than RPM/DEB packages.

ezbake generates the tarball name from the git tag (e.g. `8.13.0.SNAPSHOT.2026...`) while RPM/DEB packages use the version-release format from `ezbake.rb` (e.g. `8.13.0-0.1SNAPSHOT.2026...`). The existing glob only matches the version-release format, so the tarball is never found and not uploaded to S3.

This adds a separate glob that matches tarballs by version, covering both naming conventions. Tagged releases are not affected since the glob already matches those correctly.