### PR TITLE
Bug fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,5 @@ end
 
 group :release, optional: true do
   gem 'faraday-retry', '~> 2.1', require: false
-  # gem 'github_changelog_generator', '~> 1.16.4', require: false
-  gem 'github_changelog_generator', github: 'smortex/github-changelog-generator', branch: 'avoid-processing-a-single-commit-multiple-time', require: false
+  gem 'github_changelog_generator', '~> 1.18', require: false
 end

--- a/rakelib/changelog.rake
+++ b/rakelib/changelog.rake
@@ -16,9 +16,9 @@ else
     config.user = 'openvoxproject'
     config.project = 'openvoxdb'
     config.exclude_labels = %w[dependencies duplicate question invalid wontfix wont-fix modulesync skip-changelog]
-    # this is probably the worst way to do this
-    # ideally there would be a VERSION file and clojure and Rake would read it
-    config.future_release= '8.13.0'
+    config.future_release = File.readlines('project.clj')
+      .grep(/^\(defproject /).first[/"([^"]+)"/, 1]
+      .sub(/-SNAPSHOT\z/, '')
     # we limit the changelog to all new openvox releases, to skip perforce onces
     # otherwise the changelog generate takes a lot amount of time
     config.since_tag = '8.9.1'


### PR DESCRIPTION
### Read config.future_release from project.clj dynamically

The hardcoded version goes stale after every release. Instead, parse
the version from the defproject line in project.clj and strip the
-SNAPSHOT suffix if present.

### Update github_changelog_generator to ~> 1.18

Replace fork/outdated version pins with the released 1.18 gem which
includes the duplicate commit processing fix upstream.