### PR TITLE
Changes to prepare for 8.x branching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,13 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'The release branch to build from.'
+        type: choice
+        options:
+          - main
+          - '8.x'
+        default: 'main'
       ref:
         description: 'Tag to build'
         required: true
@@ -31,6 +38,7 @@ jobs:
   build:
     uses: 'openvoxproject/shared-actions/.github/workflows/build_ezbake.yml@main'
     with:
+      branch: ${{ inputs.branch }}
       ref: ${{ inputs.ref }}
       deb_platform_list: ${{ inputs.deb_platform_list }}
       rpm_platform_list: ${{ inputs.rpm_platform_list }}

--- a/.github/workflows/build_fips.yml
+++ b/.github/workflows/build_fips.yml
@@ -4,6 +4,13 @@ name: Build openvoxdb - FIPS platforms
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'The release branch to build from.'
+        type: choice
+        options:
+          - main
+          - '8.x'
+        default: 'main'
       ref:
         description: 'Tag to build'
         required: true
@@ -27,6 +34,7 @@ jobs:
   build:
     uses: 'openvoxproject/shared-actions/.github/workflows/build_ezbake_fips.yml@main'
     with:
+      branch: ${{ inputs.branch }}
       ref: ${{ inputs.ref }}
       rpm_platform_list: ${{ inputs.rpm_platform_list }}
       ezbake-ref: ${{ inputs.ezbake-ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 ---
 name: main
 on:
-  pull_request: {}
+  pull_request: { branches: ['main'] }
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,20 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to release from.'
+        type: choice
+        options:
+          - main
+          - '8.x'
+        default: 'main'
 
 jobs:
   release:
     uses: 'openvoxproject/shared-actions/.github/workflows/clojure_release.yml@main'
+    with:
+      base-branch: ${{ inputs.branch }}
     secrets:
       github_pat: ${{ secrets.OPENVOXBOT_COMMIT_AND_PRS }}
       ssh_private_key: ${{ secrets.OPENVOXBOT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Add branch selection to the workflow because we need to pass the branch into the shared build_ezbake and build_ezbake_fips so it can look up the right default platforms list. Also restrict PR testing to the main branch. When we make 8.x, we'll update this to 8.x there so that only main tests run on main PRs and 8.x tests on 8.x PRs.