### PR TITLE
Target openvox9 platform for main branch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -275,11 +275,11 @@
                        :group "puppetdb"
                        :build-type "foss"
                        :package-name "openvoxdb"
-                       :puppet-platform-version 8
+                       :puppet-platform-version 9
                        :main-namespace "puppetlabs.puppetdb.cli.services"
                        :start-timeout 14400
-                       :repo-target "openvox8"
-                       :nonfinal-repo-target "openvox8-nightly"
+                       :repo-target "openvox9"
+                       :nonfinal-repo-target "openvox9-nightly"
                        :logrotate-enabled false
                        :replaces-pkgs [{:package "puppetdb" :version ""}]
                        :java-args ~(str "-Xmx192m "


### PR DESCRIPTION
Now that the 8.x branch exists for OpenVox 8 releases, main becomes the OpenVox 9 development branch.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
