### PR TITLE
Use Ruby 4 for builder image and cache it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,8 +135,26 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '4.0'
           bundler-cache: true
+      - id: docker-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ hashFiles('Dockerfile') }}
+      - name: load or build docker image
+        run: |
+          if [[ -f /tmp/ezbake-builder.tar ]]; then
+            docker load -i /tmp/ezbake-builder.tar
+          else
+            docker build -t ezbake-builder .
+            docker save ezbake-builder -o /tmp/ezbake-builder.tar
+          fi
+      - uses: actions/cache/save@v4
+        if: always() && steps.docker-cache.outputs.cache-hit != 'true'
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ hashFiles('Dockerfile') }}
       - name: build it
         run: bundle exec rake vox:build
       - name: get version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM almalinux:9
+FROM ruby:4.0-bookworm
 
-WORKDIR /
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      openjdk-17-jdk-headless \
+      rpm \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN dnf install -y --enablerepo=crb vim wget git rpm-build java-17-openjdk java-17-openjdk-devel libyaml-devel zlib zlib-devel gcc-c++ patch readline readline-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison sqlite-devel
-RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
-RUN chmod a+x lein
-RUN mv lein /usr/local/bin
-RUN wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
-RUN /bin/bash --login -c 'rbenv install 3.2.9'
-RUN /bin/bash --login -c 'rbenv global 3.2.9'
-RUN git config --global user.email "openvox@voxpupuli.org"
-RUN git config --global user.name "Vox Pupuli"
-RUN git config --global --add safe.directory /code
+RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O /usr/local/bin/lein && \
+    chmod a+x /usr/local/bin/lein
 
-CMD ["tail -f /dev/null"]
+RUN git config --global user.email "openvox@voxpupuli.org" && \
+    git config --global user.name "Vox Pupuli" && \
+    git config --global --add safe.directory /code
+
+CMD ["tail", "-f", "/dev/null"]

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ def location_for(place)
 end
 
 gem 'openfact'
+gem 'ostruct'
 gem 'rake'
 gem 'packaging', '~> 1.0', github: 'OpenVoxProject/packaging'
 

--- a/project.clj
+++ b/project.clj
@@ -371,7 +371,7 @@
                                       ;; via the release_scripts/sync_ezbake_dep.rb script.
                                       [org.openvoxproject/puppetdb "9.0.0-SNAPSHOT"]]
               :name "puppetdb"
-              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.4")]]}
+              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.6")]]}
     :ezbake-fips {:dependencies ^:replace [[org.bouncycastle/bcpkix-fips]
                                            [org.bouncycastle/bc-fips]
                                            [org.bouncycastle/bctls-fips]
@@ -381,7 +381,7 @@
                                            [org.openvoxproject/puppetdb "9.0.0-SNAPSHOT"]]
               :name "puppetdb"
               :uberjar-exclusions [#"^org/bouncycastle/.*"]
-              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.4")]]}
+              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.6")]]}
     :testutils {:source-paths ^:replace ["test"]
                 :resource-paths ^:replace []
                 ;; Something else may need adjustment, but

--- a/project.clj
+++ b/project.clj
@@ -110,7 +110,7 @@
 
   :url "https://github.com/openvoxproject/openvoxdb/"
 
-  :min-lein-version "2.7.1"
+  :min-lein-version "2.12.0"
 
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.

--- a/rakelib/build.rake
+++ b/rakelib/build.rake
@@ -164,7 +164,7 @@ module Vox
       ezbake_version_var = ENV['EZBAKE_VERSION'] ? "EZBAKE_VERSION=#{ENV['EZBAKE_VERSION']}" : ""
 
       puts 'Building openvoxdb'
-      @runner.exec('cd /code && rm -rf ruby output && bundle install --without test && lein install')
+      @runner.exec('cd /code && rm -rf ruby output && bundle config set without test && bundle install && lein install')
 
       unless @debs.empty? && @nonfips_rpms.empty?
         @runner.exec(


### PR DESCRIPTION
Rather than recreate the builder container every time using rbenv, which takes quite a while, this uses the off-the-shell Ruby 4 Bookworm image. It also caches the image in GitHub for the PR job that tests the build.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
