### PR TITLE
Update ezbake to 2.7.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ def location_for(place)
 end
 
 gem 'openfact'
-gem 'ostruct'
 gem 'rake'
 gem 'packaging', '~> 1.0', github: 'OpenVoxProject/packaging'
 

--- a/project.clj
+++ b/project.clj
@@ -371,7 +371,7 @@
                                       ;; via the release_scripts/sync_ezbake_dep.rb script.
                                       [org.openvoxproject/puppetdb "9.0.0-SNAPSHOT"]]
               :name "puppetdb"
-              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.6")]]}
+              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.7")]]}
     :ezbake-fips {:dependencies ^:replace [[org.bouncycastle/bcpkix-fips]
                                            [org.bouncycastle/bc-fips]
                                            [org.bouncycastle/bctls-fips]
@@ -381,7 +381,7 @@
                                            [org.openvoxproject/puppetdb "9.0.0-SNAPSHOT"]]
               :name "puppetdb"
               :uberjar-exclusions [#"^org/bouncycastle/.*"]
-              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.6")]]}
+              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.7")]]}
     :testutils {:source-paths ^:replace ["test"]
                 :resource-paths ^:replace []
                 ;; Something else may need adjustment, but


### PR DESCRIPTION
Turns out we needed to add ostruct to ezbake's global Gemfile, not the project one.