### PR TITLE
Docker: Switch to Java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM ruby:4.0-bookworm
+FROM almalinux:10
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      openjdk-17-jdk-headless \
-      rpm \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR /
 
-RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O /usr/local/bin/lein && \
-    chmod a+x /usr/local/bin/lein
-
+RUN dnf install -y --enablerepo=crb vim wget git rpm-build java-21-openjdk-devel libyaml-devel zlib zlib-devel gcc-c++ patch readline readline-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison sqlite-devel ruby ruby-devel
+RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+RUN chmod a+x lein
+RUN mv lein /usr/local/bin
 RUN git config --global user.email "openvox@voxpupuli.org" && \
     git config --global user.name "Vox Pupuli" && \
     git config --global --add safe.directory /code


### PR DESCRIPTION
The Ruby container is based on Debian. On Debian, we don't have the rpm macros available. So we need to build our packages on an EL based distro. This now also builds on Java 21 instead of 17. For more explanation, see:

* https://github.com/OpenVoxProject/openvox-server/pull/329
* https://github.com/OpenVoxProject/openvox-server/pull/330

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
