### PR TITLE
Bump Beaker dependency to ~>6.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ if ENV['NO_ACCEPTANCE'] != 'true'
       gem 'beaker', *location_for(beaker_version)
     else
       # use the pinned version
-      gem 'beaker', '~> 6.0'
+      gem 'beaker', '~> 6.8'
     end
     gem 'beaker-hostgenerator', '~> 2.4'
     gem 'beaker-puppet', '~> 4.0'


### PR DESCRIPTION
#### Pull Request (PR) description

For some reason, `bundle install` in acceptance pipelines is deciding to install Beaker 6.6.0 instead of the 6.8.1 used by the `openvox` agent acceptance suites.

The 6.6.0 version is missing a critical fix that prevents Beaker from mis-classifying `el-10` as `el-1` and falling back to SysV service management commands:

  voxpupuli/beaker@400af53c2

This fails acceptance tests on Alma Linux 10 as that distro does not install the SysV shims by default.

This commit updates the pin from `~>6.0` to `~>6.8` which forces dependency resolution to pick the 6.8.1 version.