### PR TITLE
acceptance: Skip disabling dnf postgres on EL 10

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -620,7 +620,9 @@ module PuppetDBExtensions
         major_version = host.platform.split('-')[1]
 
         on(host, "dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-#{major_version}-x86_64/pgdg-redhat-repo-latest.noarch.rpm")
-        on(host, "dnf -qy module disable postgresql")
+        # The built-in postgres modules pre-empt the postgresql.org repos.
+        # Modules were introduced in EL 8, and deprecated in EL 10.
+        on(host, "dnf -qy module disable postgresql") if %w[8 9].include?(major_version)
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

The built-in `postgres` modules in EL 8 and EL 9 would pre-empt the postgresql.org repo and cause installation failures. The whole module sub-system is deprecated in EL 10 and the OS does not have any built-in modules by default. Trying to disable a non-existant module is an error, so this commit restricts the `dnf module disable postgresql` command to only run on EL 8 and EL 9 test systems.
