### PR TITLE
fix daily job

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -21,10 +21,10 @@ jobs:
         # These run on every branch
         flavor:
           - core+ext/openjdk21/pg-15
-          - core+ext/openjdk17/pg-15
+          - core+ext/openjdk25/pg-15
 
         os: [ubuntu-24.04]
-        ruby: ['3.2']
+        ruby: ['3.4']
 
         # Defaults for special-case influencing vars
         lein-profile: ['']
@@ -34,19 +34,19 @@ jobs:
         # Special cases
         include:
           - os: ubuntu-24.04
-            ruby: '3.2'
-            flavor: core+ext/openjdk17/pg-16
+            ruby: '3.4'
+            flavor: core+ext/openjdk21/pg-16
             drop-joins: by-request
           - os: ubuntu-24.04
-            ruby: '3.2'
-            flavor: core+ext/openjdk17/pg-16
+            ruby: '3.4'
+            flavor: core+ext/openjdk21/pg-16
             lein-profile: fips
 
           # non-rich variants for main
           - os: ubuntu-24.04
             branch: main
-            ruby: '3.2'
-            flavor: int/openjdk17/pup-main/srv-main/pg-16
+            ruby: '3.4'
+            flavor: int/openjdk21/pup-main/srv-main/pg-16
 
     steps:
       - name: Compute job outputs

--- a/test/puppetlabs/puppetdb/integration/file_with_binary_template.clj
+++ b/test/puppetlabs/puppetdb/integration/file_with_binary_template.clj
@@ -5,38 +5,41 @@
    [me.raynes.fs :as fs]
    [puppetlabs.puppetdb.integration.fixtures :as int]))
 
+(defn- puppet-major-version []
+  (some-> (int/bundle-exec {} "puppet" "--version")
+          :out
+          str/trim-newline
+          (#(re-matches #"^(\d+).*" %))
+          second
+          Integer/parseInt))
+
 (deftest ^:integration file-with-binary-template
   ;; Puppet 8 removes the ability to serialize binary files without using the
   ;; rich data type Binary, or installing the puppet-pson gem
-  (when (< 8
-           (->> (int/bundle-exec {} "puppet" "--version")
-                :out
-                str/trim-newline
-                (re-matches #"^(\d+).*")
-                second
-                (Integer/parseInt)))
-    (with-open [pg (int/setup-postgres)
-                pdb (int/run-puppetdb pg {})
-                ps (int/run-puppet-server [pdb] {})]
+  (let [version (puppet-major-version)]
+    (when (and version (< version 8))
+      (with-open [pg (int/setup-postgres)
+                  pdb (int/run-puppetdb pg {})
+                  ps (int/run-puppet-server [pdb] {})]
 
-      (let [temp-dir (fs/temp-dir "file-with-binary-template")
-            file-resource-path (str temp-dir "/binary-file")
-            binary-template-path (fs/absolute "test-resources/binary-template.erb")]
+        (let [temp-dir (fs/temp-dir "file-with-binary-template")
+              file-resource-path (str temp-dir "/binary-file")
+              binary-template-path (fs/absolute "test-resources/binary-template.erb")]
 
-        (testing "Run puppet with a binary template"
-          (int/run-puppet ps pdb
-                          (str "file { '" file-resource-path "':"
-                               "  content => template('" binary-template-path "'),"
-                               "  tag => 'binary_file',"
-                               "}")
-                          {:certname "binary-file-agent"
-                           ;; this is a workaround for puppet's present inability to automatically
-                           ;; downgrade from json to pson; it will be removed once
-                           ;; that feature is added.
-                           :extra-puppet-args ["--preferred_serialization_format" "pson"]}))
+          (testing "Run puppet with a binary template"
+            (int/run-puppet ps pdb
+                            (str "file { '" file-resource-path "':"
+                                 "  content => template('" binary-template-path "'),"
+                                 "  tag => 'binary_file',"
+                                 "}")
+                            {:certname "binary-file-agent"
+                             ;; this is a workaround for puppet's present inability to automatically
+                             ;; downgrade from json to pson; it will be removed once
+                             ;; that feature is added.
+                             :extra-puppet-args ["--preferred_serialization_format" "pson"]}))
 
-        (testing "PDB should have stored the resource"
-          (is (= {:certname "binary-file-agent"
-                  :type "File"
-                  :title file-resource-path}
-                 (first (int/pql-query pdb "resources [certname, type, title] { tag = 'binary_file' }")))))))))
+          (testing "PDB should have stored the resource"
+            (is (= {:certname "binary-file-agent"
+                    :type "File"
+                    :title file-resource-path}
+                   (first (int/pql-query pdb "resources [certname, type, title] { tag = 'binary_file' }"))))))))))


### PR DESCRIPTION
- CI: ruby 3.2->3.4
- CI: JDK 17->21 (or 17->25)
  - JDK 17 support was dropped in 2143b725ba8514a8247426535dc0521a79a3d3f5
- implement correct check for only running test when Puppet < 8