### PR TITLE
Fix Jolokia 2.x configuration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -413,7 +413,12 @@
   :uberjar-merge-with {"locales.clj"  [(comp read-string slurp)
                                        (fn [new prev]
                                          (if (map? prev) [new prev] (conj prev new)))
-                                       #(spit %1 (pr-str %2))]}
+                                       #(spit %1 (pr-str %2))]
+
+                       ;; Jolokia 2.0 implemented a services architecture and
+                       ;; the default service lists from each dependency must
+                       ;; be combined to create a working configuration.
+                       "META-INF/jolokia/services-default" [slurp str spit]}
 
   ;; We define our own release tasks here, rather than the default that 'lein release' does,
   ;; so that we can keep the necessary org.openvoxproject/puppetdb ezbake dependency in sync.


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

The Jolokia 2.0 release split the library into multiple dependencies and implemented a services architecture that requires a list of service components to load from each dependency. The default configuration is stored in the following file within each JAR:

    META-INF/jolokia/services-default

This works when the `jolokia-service-jmx` and `jolokia-service-serializer` dependencies exist as separate `.jar` files on the Classpath. When combined into an uberjar, one `services-default` file overwrites the other and the result is half of a working configuration.

This commit fixes the issue by configuring `project.clj` to merge the contents of `services-default` files when building an uberjar.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
