### PR TITLE
Set version number to 8.14.1-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -102,7 +102,7 @@
 
 ;; If you modify the version manually, run release_scripts/sync_ezbake_dep.rb to keep
 ;; the ezbake dependency in sync.
-(defproject org.openvoxproject/puppetdb "8.15.0-SNAPSHOT"
+(defproject org.openvoxproject/puppetdb "8.14.1-SNAPSHOT"
   :description "OpenVox-integrated catalog and fact storage"
 
   :license {:name "Apache License, Version 2.0"
@@ -369,7 +369,7 @@
                                       ;;
                                       ;; Do not modify this line. It is managed by the release process
                                       ;; via the release_scripts/sync_ezbake_dep.rb script.
-                                      [org.openvoxproject/puppetdb "8.15.0-SNAPSHOT"]]
+                                      [org.openvoxproject/puppetdb "8.14.1-SNAPSHOT"]]
               :name "puppetdb"
               :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.9")]]}
     :ezbake-fips {:dependencies ^:replace [[org.bouncycastle/bcpkix-fips]
@@ -378,7 +378,7 @@
                                            [org.clojure/clojure]
                                            ;; Do not modify this line. It is managed by the release process
                                            ;; via the release_scripts/sync_ezbake_dep.rb script.
-                                           [org.openvoxproject/puppetdb "8.15.0-SNAPSHOT"]]
+                                           [org.openvoxproject/puppetdb "8.14.1-SNAPSHOT"]]
               :name "puppetdb"
               :uberjar-exclusions [#"^org/bouncycastle/.*"]
               :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.9")]]}


### PR DESCRIPTION
The next version will be 8.14.1 as it only contains a couple of bugfixes to package scripts and metrics reporting.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
