### PR TITLE
fix FIPS tests by using correct path to java.security.fips

### DIFF
--- a/ci/bin/run
+++ b/ci/bin/run
@@ -14,6 +14,21 @@ test $# -eq 1 || misuse
 spec="$1"
 flavor=$(ext/bin/flavor-from-spec "$spec")
 
+# Fail fast in FIPS CI when provider wiring is broken, before long-running tests.
+fips-keystore-sanity-check() {
+    local profiles="${LEIN_PROFILES:-dev}"
+    if [[ ! "$profiles" =~ (^|,)(\+)?fips($|,) ]]; then
+        return 0
+    fi
+
+    local cp
+    cp="$(lein with-profiles "$profiles" classpath)"
+    java -Djava.security.properties==resources/ext/java.security.fips \
+         -cp "$cp" clojure.main \
+         -e '(java.security.KeyStore/getInstance "BCFKS")' \
+         >/dev/null
+}
+
 case "$flavor" in
     core|ext|core+ext)
         # Get PostgreSQL version from test spec
@@ -25,6 +40,7 @@ case "$flavor" in
         ext/bin/check-spec-env "$spec"
         case "$flavor" in
             core|core+ext)
+                fips-keystore-sanity-check
                 # Run core lein tests with ephemeral PuppetDB and PostgreSQL sandboxes
                 # Leiningen dev profile adds org.bouncycastle/bcpkix-jdk18on dependency
                 ext/bin/boxed-core-tests --pglog pg.log \

--- a/project.clj
+++ b/project.clj
@@ -335,8 +335,8 @@
                     :jvm-opts ~(let [{:keys [feature interim]} pdb-jvm-ver]
                                   (conj pdb-jvm-opts
                                         (case feature
-                                          17 "-Djava.security.properties==resources/ext/build-scripts/java.security.fips"
-                                          21 "-Djava.security.properties==resources/ext/build-scripts/java.security.fips"
+                                          17 "-Djava.security.properties==resources/ext/java.security.fips"
+                                          21 "-Djava.security.properties==resources/ext/java.security.fips"
                                           (do))))}
 
     :fips [:defaults :fips-settings]


### PR DESCRIPTION
- CI: add fail fast check for FIPS in daily
- java.security.fips was introduced in 13a869afc66471f031a2155deef19b1423ff079e, but later moved in cac43ba149d16bf30930aa6d1fb1a7fbeb1c81e2