### PR TITLE
Addutional FIPS DRBG (deterministic random bit generator) limit changes

### DIFF
--- a/src/puppetlabs/puppetdb/cli/benchmark.clj
+++ b/src/puppetlabs/puppetdb/cli/benchmark.clj
@@ -153,8 +153,7 @@
                          ScheduledThreadPoolExecutor
                          Semaphore
                          TimeUnit)
-   (org.apache.commons.compress.archivers.tar TarArchiveEntry)
-   (org.apache.commons.lang3 RandomStringUtils)))
+   (org.apache.commons.compress.archivers.tar TarArchiveEntry)))
 
 ;; FIXME: make sure --queriers respects DISCARD_ALL_QUERIES
 
@@ -311,9 +310,9 @@
 (defmethod touch-parameter-value String [p]
   (let [len (count p)]
     (if (zero? len)
-      (.nextAscii (RandomStringUtils/secure) 1)  ; empty -> single char
+      (rnd/random-ascii-string 1)  ; empty -> single char
       (loop [attempts 5]
-        (let [new-val (.nextAscii (RandomStringUtils/secure) len)]
+        (let [new-val (rnd/random-ascii-string len)]
           (if (or (not= new-val p) (zero? attempts))
             new-val
             (recur (dec attempts))))))))

--- a/src/puppetlabs/puppetdb/cli/generate.clj
+++ b/src/puppetlabs/puppetdb/cli/generate.clj
@@ -243,10 +243,7 @@
     [puppetlabs.puppetdb.utils :as utils])
   (:import
     [java.nio.file.attribute FileAttribute]
-    [java.nio.file Files]
-    [org.apache.commons.lang3 RandomStringUtils]))
-
-(declare random-ascii-string)
+    [java.nio.file Files]))
 
 (def resource-fact-path "puppetlabs/puppetdb/generate/samples/facts/baseline-agent-node.json")
 
@@ -337,7 +334,7 @@
         (recur (assoc parameters
                       (parameter-name
                         (rnd/safe-sample-normal 20 5 {:lowerb 5}))
-                      (random-ascii-string
+                      (rnd/random-ascii-string
                         (rnd/safe-sample-normal 50 25 {:upperb (max 50 size)}))))
         parameters))))
 
@@ -463,29 +460,6 @@
    :target (select-keys target [:type :title])
    :relationship relation})
 
-(defn- random-ascii-string
-  "Generate a random ASCII string of the given length.
-
-   Chunks requests to stay within the BouncyCastle FIPS DRBG per-request limit
-   of 262144 bits (32768 bytes). Apache Commons Lang3's RandomStringUtils
-   allocates a CachedRandomBits with size = (count * gapBits + 3) / 5 + 10
-   bytes. For nextAscii (ASCII range 32-127, gap=95, gapBits=7) the maximum
-   count that keeps the cache within 32768 bytes is:
-     (count * 7 + 3) / 5 + 10 <= 32768  =>  count <= 23398"
-  [length]
-  (let [fips-max-chunk 23398
-        ^RandomStringUtils secure-random (RandomStringUtils/secure)]
-    (if (<= length fips-max-chunk)
-      (.nextAscii secure-random length)
-      ;; Build incrementally to avoid intermediate vectors/strings for large values.
-      (let [^StringBuilder builder (StringBuilder. length)]
-        (loop [remaining length]
-          (if (<= remaining 0)
-            (.toString builder)
-            (let [chunk-size (min remaining fips-max-chunk)]
-              (.append builder (.nextAscii secure-random chunk-size))
-              (recur (- remaining chunk-size)))))))))
-
 (defn add-blob
   "Add a large parameter string blob to one of the given catalog's resource parameters.
 
@@ -505,7 +479,7 @@
         bsize (rnd/safe-sample-normal avg-blob-size-in-bytes standard-deviation {:lowerb lowerb :upperb upperb})
         pname (format "content_blob_%s" (rnd/random-pronouncable-word))]
     (update-in catalog [:resources (rand-int (count resources)) :parameters]
-               #(merge % {pname (random-ascii-string bsize)}))))
+               #(merge % {pname (rnd/random-ascii-string bsize)}))))
 
 (defn system-seconds-str
   "Epoch seconds as a string. Used by default as a version string in Puppet

--- a/src/puppetlabs/puppetdb/random.clj
+++ b/src/puppetlabs/puppetdb/random.clj
@@ -10,50 +10,42 @@
 (def ^{:doc "Convenience for java.util.Random"}
   random (java.util.Random.))
 
-(defn- alphabetic-string
-  "Generate a random alphabetic string of the given length.
-
-   Chunks requests to stay within the BouncyCastle FIPS DRBG per-request limit
-   of 262144 bits. Apache Commons Lang3's CachedRandomBits allocates
-   (count * gapBits + 3) / 5 + 10 bytes per call. For nextAlphabetic
-   (A-Z + a-z = 52 chars, gapBits = ceil(log2(52)) = 6) the maximum count per call is:
-   (count * 6 + 3) / 5 + 10 <= 32768  =>  count <= 27298"
-  [length]
-  (let [fips-max-chunk 27298
-        ^RandomStringUtils secure-random (RandomStringUtils/secure)]
-    (if (<= length fips-max-chunk)
-      (.nextAlphabetic secure-random length)
-      ;; Build incrementally to avoid intermediate vectors/strings for large values.
-      (let [^StringBuilder builder (StringBuilder. length)]
-        (loop [remaining length]
-          (if (<= remaining 0)
-            (.toString builder)
-            (let [chunk-size (min remaining fips-max-chunk)]
-              (.append builder (.nextAlphabetic secure-random chunk-size))
-              (recur (- remaining chunk-size)))))))))
-
-(defn random-ascii-string
-  "Generate a random ASCII string of the given length.
+(defn- chunked-random-string
+  "Generate a random alphabetic or ascii string of the given length.
 
    Chunks requests to stay within the BouncyCastle FIPS DRBG per-request limit
    of 262144 bits (32768 bytes). Apache Commons Lang3's RandomStringUtils
    allocates a CachedRandomBits with size = (count * gapBits + 3) / 5 + 10
-   bytes. For nextAscii (ASCII range 32-127, gap=95, gapBits=7) the maximum
-   count that keeps the cache within 32768 bytes is:
-     (count * 7 + 3) / 5 + 10 <= 32768  =>  count <= 23398"
-  [length]
-  (let [fips-max-chunk 23398
-        ^RandomStringUtils secure-random (RandomStringUtils/secure)]
+   bytes.
+
+   For nextAscii (ASCII range 32-127, gap=95, gapBits=7)
+   the maximum count that keeps the cache within 32768 bytes is:
+     (count * 7 + 3) / 5 + 10 <= 32768  =>  count <= 23398
+
+   For nextAlphabetic (A-Z + a-z = 52 chars, gapBits = ceil(log2(52)) = 6)
+   the maximum count per call is:
+     (count * 6 + 3) / 5 + 10 <= 32768  =>  count <= 27298"
+  [method length]
+  (let [^RandomStringUtils secure-random (RandomStringUtils/secure)
+        [gen-fn fips-max-chunk] (case method
+                                  :ascii    [#(.nextAscii ^RandomStringUtils secure-random %) 23398]
+                                  :alphabetic [#(.nextAlphabetic ^RandomStringUtils secure-random %) 27298])]
     (if (<= length fips-max-chunk)
-      (.nextAscii secure-random length)
+      (gen-fn length)
       ;; Build incrementally to avoid intermediate vectors/strings for large values.
       (let [^StringBuilder builder (StringBuilder. length)]
         (loop [remaining length]
           (if (<= remaining 0)
             (.toString builder)
             (let [chunk-size (min remaining fips-max-chunk)]
-              (.append builder (.nextAscii secure-random chunk-size))
+              (.append builder (gen-fn chunk-size))
               (recur (- remaining chunk-size)))))))))
+
+(defn- alphabetic-string [length]
+  (chunked-random-string :alphabetic length))
+
+(defn random-ascii-string [length]
+  (chunked-random-string :ascii length))
 
 (defn random-string
   "Generate a random string of optional length"

--- a/src/puppetlabs/puppetdb/random.clj
+++ b/src/puppetlabs/puppetdb/random.clj
@@ -57,13 +57,13 @@
 
 (defn random-string
   "Generate a random string of optional length"
-  ([] (.nextAlphabetic (RandomStringUtils/secure) (inc (rand-int 10))))
+  ([] (alphabetic-string (inc (rand-int 10))))
   ([length]
    (alphabetic-string length)))
 
 (defn random-string-alpha
   "Generate a random string of optional length, only lower case alphabet chars"
-  ([] (random-string (inc (rand-int 10))))
+  ([] (random-string-alpha (inc (rand-int 10))))
   ([length]
    (.toLowerCase (alphabetic-string length))))
 

--- a/src/puppetlabs/puppetdb/random.clj
+++ b/src/puppetlabs/puppetdb/random.clj
@@ -32,6 +32,29 @@
               (.append builder (.nextAlphabetic secure-random chunk-size))
               (recur (- remaining chunk-size)))))))))
 
+(defn random-ascii-string
+  "Generate a random ASCII string of the given length.
+
+   Chunks requests to stay within the BouncyCastle FIPS DRBG per-request limit
+   of 262144 bits (32768 bytes). Apache Commons Lang3's RandomStringUtils
+   allocates a CachedRandomBits with size = (count * gapBits + 3) / 5 + 10
+   bytes. For nextAscii (ASCII range 32-127, gap=95, gapBits=7) the maximum
+   count that keeps the cache within 32768 bytes is:
+     (count * 7 + 3) / 5 + 10 <= 32768  =>  count <= 23398"
+  [length]
+  (let [fips-max-chunk 23398
+        ^RandomStringUtils secure-random (RandomStringUtils/secure)]
+    (if (<= length fips-max-chunk)
+      (.nextAscii secure-random length)
+      ;; Build incrementally to avoid intermediate vectors/strings for large values.
+      (let [^StringBuilder builder (StringBuilder. length)]
+        (loop [remaining length]
+          (if (<= remaining 0)
+            (.toString builder)
+            (let [chunk-size (min remaining fips-max-chunk)]
+              (.append builder (.nextAscii secure-random chunk-size))
+              (recur (- remaining chunk-size)))))))))
+
 (defn random-string
   "Generate a random string of optional length"
   ([] (.nextAlphabetic (RandomStringUtils/secure) (inc (rand-int 10))))

--- a/test/puppetlabs/puppetdb/random_test.clj
+++ b/test/puppetlabs/puppetdb/random_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [puppetlabs.puppetdb.random
     :refer [distribute
+            random-ascii-string
             random-bool
             random-node-name
             random-pp-path
@@ -16,9 +17,14 @@
 
 (deftest test-random-string
   (testing "should return a string of specified length"
+    (is (>= 10 (count (random-string))))
     (is (= 8 (count (random-string 8))))
     (is (= 30 (count (random-string 30))))
     (is (= 100 (count (random-string 100)))))
+
+  (testing "should only contain alphabetic characters"
+    (is (re-matches #"\A[a-zA-Z]+\z" (random-string)))
+    (is (re-matches #"\A[a-zA-Z]{100}\z" (random-string 100))))
 
   (testing "should only accept a positive integer"
     (is (thrown? IllegalArgumentException (random-string -1)))
@@ -26,13 +32,31 @@
 
 (deftest test-random-string-alpha
   (testing "should return a string of specified length"
+    (is (>= 10 (count (random-string-alpha))))
     (is (= 8 (count (random-string-alpha 8))))
     (is (= 30 (count (random-string-alpha 30))))
     (is (= 100 (count (random-string-alpha 100)))))
 
+  (testing "should only contain lowercase alphabetic characters"
+    (is (re-matches #"\A[a-z]+\z" (random-string-alpha)))
+    (is (re-matches #"\A[a-z]{100}\z" (random-string-alpha 100))))
+
   (testing "should only accept a positive integer"
     (is (thrown? IllegalArgumentException (random-string-alpha -1)))
     (is (thrown? ClassCastException (random-string-alpha "asdf")))))
+
+(deftest test-random-ascii-string
+  (testing "should return a string of specified length"
+    (is (= 8 (count (random-ascii-string 8))))
+    (is (= 30 (count (random-ascii-string 30))))
+    (is (= 100 (count (random-ascii-string 100)))))
+
+  (testing "should only contain ascii characters"
+    (is (re-matches #"\A[\x20-\x7E]{100}\z" (random-ascii-string 100))))
+
+  (testing "should only accept a positive integer"
+    (is (thrown? IllegalArgumentException (random-ascii-string -1)))
+    (is (thrown? ClassCastException (random-ascii-string "asdf")))))
 
 (deftest test-random-bool
   (testing "should return a boolean"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
Builds on changes from #343

* Move random-ascii-string into the random.clj namespace so that it is contained with the rest of the random functions there.
* Extract chunk-random-string in random.clj from near identical alphabetic-string and random-ascii-string.
* Use random-ascii-string in benchmark.clj as well, where there was one other use of RandomStringUtils.nextAscii() that could have hit similar FIPS limits
* Adds a few test cases for the changed functions
* Corrects a couple of bugs in two of the existing random.clj random string functions

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
