### PR TITLE
Replace use of --configprint in ssl-setup

### DIFF
--- a/resources/ext/cli/ssl-setup.erb
+++ b/resources/ext/cli/ssl-setup.erb
@@ -238,8 +238,8 @@ then
 else
   # This should be run on the host with PuppetDB
   PATH=/opt/puppetlabs/bin:/opt/puppet/bin:$PATH
-  agent_confdir=`puppet agent --configprint confdir`
-  agent_vardir=`puppet agent --configprint vardir`
+  agent_confdir=$(puppet config print confdir)
+  agent_vardir=$(puppet config print vardir)
   user=<%= EZBake::Config[:user] %>
   group=<%= EZBake::Config[:group] %>
 
@@ -248,11 +248,11 @@ fi
 
 set -e
 
-mycertname=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint  certname`
+mycertname=$(puppet config print --confdir=$agent_confdir --vardir=$agent_vardir --section=agent certname)
 
-orig_public_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint  hostcert`
-orig_private_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint hostprivkey`
-orig_ca_file=`puppet agent --confdir=$agent_confdir --vardir=$agent_vardir --configprint localcacert`
+orig_public_file=$(puppet config print --confdir=$agent_confdir --vardir=$agent_vardir --section=agent hostcert)
+orig_private_file=$(puppet config print --confdir=$agent_confdir --vardir=$agent_vardir --section=agent hostprivkey)
+orig_ca_file=$(puppet config print --confdir=$agent_confdir --vardir=$agent_vardir --section=agent localcacert)
 
 ssl_dir=${puppetdb_confdir}/ssl
 


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

The `puppetdb ssl-setup` command used `puppet agent --configprint` in quite a few places. This option no longer exists as of OpenVoxProject/openvox#374.

This commit replaces usages of `--configprint` with `puppet config print`.


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
