### PR TITLE
Bump beaker version to 7.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,9 +65,8 @@ if ENV['NO_ACCEPTANCE'] != 'true'
       gem 'beaker', *location_for(beaker_version)
     else
       # use the pinned version
-      gem 'beaker', '~> 6.8'
+      gem 'beaker', '~> 7.6'
     end
-    gem 'beaker-hostgenerator', '~> 2.4'
     gem 'beaker-puppet', '~> 4.0'
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

This commit bumps the beaker version required by tests to 7.6, and also bumps the versions of various beaker plugins. The explicit dependency on `beaker-hostgenerator` is dropped as the `beaker` gem its self has this dependency.


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
