### PR TITLE
Update integration tests to expect Ruby 3.4 output

### DIFF
--- a/test/puppetlabs/puppetdb/integration/reports.clj
+++ b/test/puppetlabs/puppetdb/integration/reports.clj
@@ -105,9 +105,9 @@
     [
      ; for undef and false a wrapper is required or message is interpreted as 'absent' and no change occurs
      {:name "literal_undef" :code "{ 'wrapper' => [undef] }"
-      :expected "{\"wrapper\"=>[nil]}"}
+      :expected "{\"wrapper\" => [nil]}"}
      {:name "literal_false" :code "{ 'wrapper' => false }"
-      :expected "{\"wrapper\"=>false}"}
+      :expected "{\"wrapper\" => false}"}
 
      {:name "literal_default" :code "default" :expected "default"}
      {:name "literal_integer" :code "47" :expected "47"}
@@ -126,15 +126,15 @@
      {:name "timestamp" :code "Timestamp('2012-10-10')"
       :expected "2012-10-10T00:00:00.000000000 UTC"}
      {:name "hash_and_array" :code "{'a' => [1, 2, 3], 'b' => 'hello'}"
-      :expected "{\"a\"=>[1, 2, 3], \"b\"=>\"hello\"}"}
+      :expected "{\"a\" => [1, 2, 3], \"b\" => \"hello\"}"}
      {:name "special_key" :code "{ ['special', 'key'] => 10 }"
-      :expected "{\"[\\\"special\\\", \\\"key\\\"]\"=>10}"}
+      :expected "{\"[\\\"special\\\", \\\"key\\\"]\" => 10}"}
      {:name "hash_with_sensitive_val" :code "{ x => Sensitive(hush) }"
-      :expected #"\{\"x\"=>\"#<Sensitive \[value redacted\]:[0-9]+>\"}"}
+      :expected #"\{\"x\" => \"#<Sensitive \[value redacted\]:[0-9]+>\"}"}
      {:name "hash_with_sensitive_key" :code "{Sensitive(hush) => 42 }"
-      :expected #"\{\"#<Sensitive \[value redacted\]:[0-9]+>\"=>42\}"}
+      :expected #"\{\"#<Sensitive \[value redacted\]:[0-9]+>\" => 42\}"}
      {:name "hash_ptype_key" :code "{'__ptype' => 10}"
-      :expected "{\"reserved key: __ptype\"=>10}"}
+      :expected "{\"reserved key: __ptype\" => 10}"}
      {:name "binary_value" :code "Binary(\"hello\", \"%s\")" :expected "aGVsbG8="}
      {:name "a_type" :code "Integer[0,100]" :expected "Integer[0, 100]"}
 


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

JRuby 10 has landed over in OpenVox Server, which means Ruby language behavior has moved from Ruby 3.1 to Ruby 3.4. This brought in a 3.4 change to how `Hash#inspect` stringifies data:

  https://bugs.ruby-lang.org/issues/20433

This commit updates the OpenVoxDB integration tests to expect the new `{a => b}` output instead of the older, compact, `{a=>b}` output.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
