### PR TITLE
Build JARs with Java version based on branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     uses: 'openvoxproject/shared-actions/.github/workflows/clojure_release.yml@main'
     with:
       base-branch: ${{ inputs.branch }}
+      java-version: ${{ case(inputs.branch == '8.x', '17', '21') }}
     secrets:
       github_pat: ${{ secrets.OPENVOXBOT_COMMIT_AND_PRS }}
       ssh_private_key: ${{ secrets.OPENVOXBOT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

This commit updates the release workflow to use Java 17 to build the JAR files if releasing from the `8.x` branch, otherwise Java 21 is used.


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
