### PR TITLE
Release cleanup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -381,7 +381,7 @@
                                       ;; via the release_scripts/sync_ezbake_dep.rb script.
                                       [org.openvoxproject/puppetdb "9.0.0-beta2-SNAPSHOT"]]
               :name "puppetdb"
-              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.8.0")]]}
+              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.9.0")]]}
     :ezbake-fips {:dependencies ^:replace [[org.bouncycastle/bcpkix-fips]
                                            [org.bouncycastle/bc-fips]
                                            [org.bouncycastle/bctls-fips]
@@ -391,7 +391,7 @@
                                            [org.openvoxproject/puppetdb "9.0.0-beta2-SNAPSHOT"]]
               :name "puppetdb"
               :uberjar-exclusions [#"^org/bouncycastle/.*"]
-              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.8.0")]]}
+              :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.9.0")]]}
     :testutils {:source-paths ^:replace ["test"]
                 :resource-paths ^:replace []
                 ;; Something else may need adjustment, but

--- a/project.clj
+++ b/project.clj
@@ -107,7 +107,7 @@
 
 ;; If you modify the version manually, run release_scripts/sync_ezbake_dep.rb to keep
 ;; the ezbake dependency in sync.
-(defproject org.openvoxproject/puppetdb "9.1.0-SNAPSHOT"
+(defproject org.openvoxproject/puppetdb "9.0.0-beta2-SNAPSHOT"
   :description "OpenVox-integrated catalog and fact storage"
 
   :license {:name "Apache License, Version 2.0"
@@ -379,7 +379,7 @@
                                       ;;
                                       ;; Do not modify this line. It is managed by the release process
                                       ;; via the release_scripts/sync_ezbake_dep.rb script.
-                                      [org.openvoxproject/puppetdb "9.1.0-SNAPSHOT"]]
+                                      [org.openvoxproject/puppetdb "9.0.0-beta2-SNAPSHOT"]]
               :name "puppetdb"
               :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.8.0")]]}
     :ezbake-fips {:dependencies ^:replace [[org.bouncycastle/bcpkix-fips]
@@ -388,7 +388,7 @@
                                            [org.clojure/clojure]
                                            ;; Do not modify this line. It is managed by the release process
                                            ;; via the release_scripts/sync_ezbake_dep.rb script.
-                                           [org.openvoxproject/puppetdb "9.1.0-SNAPSHOT"]]
+                                           [org.openvoxproject/puppetdb "9.0.0-beta2-SNAPSHOT"]]
               :name "puppetdb"
               :uberjar-exclusions [#"^org/bouncycastle/.*"]
               :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.8.0")]]}

--- a/rakelib/build.rake
+++ b/rakelib/build.rake
@@ -32,7 +32,7 @@ module Vox
       # To be fixed one of these days. Relevant stuff:
       #   https://github.com/puppetlabs/ezbake/blob/aeb7735a16d2eecd389a6bd9e5c0cfc7c62e61a5/resources/puppetlabs/lein-ezbake/template/global/tasks/build.rake
       #   https://github.com/puppetlabs/ezbake/blob/aeb7735a16d2eecd389a6bd9e5c0cfc7c62e61a5/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
-      deb_platforms = ENV['DEB_PLATFORMS'] || 'ubuntu-22.04,ubuntu-24.04,ubuntu-25.04,ubuntu-25.10,ubuntu-26.04,debian-13'
+      deb_platforms = ENV['DEB_PLATFORMS'] || 'ubuntu-22.04,ubuntu-24.04,ubuntu-26.04,debian-13'
       debs = deb_platforms.split(',').map { |p| "base-#{p.split("-").join}-i386.cow" }.join(" ")
 
       rpm_platforms = ENV['RPM_PLATFORMS'] || 'el-8,el-9,el-10,sles-15,sles-16,amazon-2023,fedora-43,fedora-44'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description


This changeset includes a couple of clean-up items from the beta1 release:

  - Set version back to `9.0.0-beta2-SNAPSHOT`
  - Bump EZbake to 2.9.0
  - Remove Ubuntu 25.04 and 25.10 from the list of default EZbake builds

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
