### PR TITLE
reduce average footprint by 20 (upper and lower bound)

### DIFF
--- a/test/puppetlabs/puppetdb/cli/generate_test.clj
+++ b/test/puppetlabs/puppetdb/cli/generate_test.clj
@@ -81,7 +81,7 @@
         total-footprint (reduce + footprints)
         avg-footprint (quot total-footprint (count resources))]
     (is (= 100 (count resources)))
-    (is (< 400 avg-footprint 600))
+    (is (< 380 avg-footprint 580))
     (is (< 40000 total-footprint  60000))))
 
 (deftest add-blob-test


### PR DESCRIPTION
~~Note: Not to be backported to 8.x**~~ Looks like a backport is needed, as tests are also randomly failing on `8.x` branch.