### PR TITLE
prep for clj-kondo bump to 2026.07.24

### DIFF
--- a/src/puppetlabs/puppetdb/query/paging.clj
+++ b/src/puppetlabs/puppetdb/query/paging.clj
@@ -114,7 +114,7 @@
   was successful; throws an exception with a useful error message otherwise."
   [order_by]
   (if-let [bad-order-by (some
-                         (fn [x] (when (keys (dissoc x :field :order)) x))
+                         (fn [x] (when (seq (dissoc x :field :order)) x))
                          order_by)]
     (throw (bad-query-ex
             (tru "Illegal value ''{0}'' in :order_by; unknown key ''{1}''."

--- a/src/puppetlabs/puppetdb/scf/storage.clj
+++ b/src/puppetlabs/puppetdb/scf/storage.clj
@@ -1980,7 +1980,7 @@
 (s/defn add-report! :- processing-status-schema
   "Add a report and all of the associated events to the database."
   ([report received-timestamp db conn-status]
-   (add-report! report received-timestamp db conn-status true))
+   (add-report! report received-timestamp db conn-status nil))
   ([{:keys [certname producer_timestamp] :as report} :- reports/report-wireformat-schema
    received-timestamp :- pls/Timestamp
    db conn-status

--- a/test/puppetlabs/puppetdb/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/catalogs_test.clj
@@ -39,6 +39,7 @@
       (is (thrown? AssertionError (resource-spec-to-map "Class[Foo")))
       (is (thrown? AssertionError (resource-spec-to-map "ClassFoo]")))
       (is (thrown? AssertionError (resource-spec-to-map "ClassFoo")))
+      #_{:clj-kondo/ignore [:type-mismatch]}
       (is (thrown? AssertionError (resource-spec-to-map nil))))
 
     (testing "should correctly parse well-formed input"

--- a/test/puppetlabs/puppetdb/random_test.clj
+++ b/test/puppetlabs/puppetdb/random_test.clj
@@ -28,6 +28,7 @@
 
   (testing "should only accept a positive integer"
     (is (thrown? IllegalArgumentException (random-string -1)))
+    #_{:clj-kondo/ignore [:type-mismatch]}
     (is (thrown? ClassCastException (random-string "asdf")))))
 
 (deftest test-random-string-alpha
@@ -43,6 +44,7 @@
 
   (testing "should only accept a positive integer"
     (is (thrown? IllegalArgumentException (random-string-alpha -1)))
+    #_{:clj-kondo/ignore [:type-mismatch]}
     (is (thrown? ClassCastException (random-string-alpha "asdf")))))
 
 (deftest test-random-ascii-string
@@ -56,6 +58,7 @@
 
   (testing "should only accept a positive integer"
     (is (thrown? IllegalArgumentException (random-ascii-string -1)))
+    #_{:clj-kondo/ignore [:type-mismatch]}
     (is (thrown? ClassCastException (random-ascii-string "asdf")))))
 
 (deftest test-random-bool

--- a/test/puppetlabs/puppetdb/testutils/services.clj
+++ b/test/puppetlabs/puppetdb/testutils/services.clj
@@ -458,7 +458,7 @@
   "Returns the number of messages discarded from the command queue by
   the current PuppetDB instance."
   []
-  (-> (pdb-metrics-url "/mbeans/puppetlabs.puppetdb.command:type=global,name=discarded")
+  (-> (metrics-url-str "/mbeans/puppetlabs.puppetdb.command:type=global,name=discarded")
       get-or-throw
       (get-in [:body :Count])))
 


### PR DESCRIPTION
- in preparation for #433/#435
- fix lint regressions
- adjust paging/report defaults
- fix metrics helper usage
- fix scope ignores for intentional negative tests