### PR TITLE
openvoxdb-terminus: Allow openvox 9

### DIFF
--- a/contrib/gem/openvoxdb-terminus.gemspec
+++ b/contrib/gem/openvoxdb-terminus.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  # dependencies here don't really matter because we currently package the terminus only as openvoxdb-termini deb/rpm.
+  # not as gem
   gem.add_runtime_dependency 'json'
-  gem.add_runtime_dependency 'openvox', '> 8.19', '< 9'
+  gem.add_runtime_dependency 'openvox', '> 8.19', '< 10'
 end


### PR DESCRIPTION
adding `skip-changelog` because we don't use the gemspec at all at the moment