### PR TITLE
fix: match pre-release tarballs by base version on upload

### DIFF
--- a/rakelib/upload.rake
+++ b/rakelib/upload.rake
@@ -42,9 +42,12 @@ namespace :vox do
     # Tarballs use a different version format than RPM/DEB packages.
     # ezbake generates the tarball name from the git tag (e.g. 8.13.0.SNAPSHOT.2026...)
     # while RPM/DEB use the version-release format (e.g. 8.13.0-0.1SNAPSHOT.2026...).
-    # Match tarballs separately by version to cover both formats.
+    # Pre-releases add a tilde suffix to the version here (e.g. 9.0.0~beta1) that the
+    # git-tag tarball name lacks, so match on the base version to cover snapshots and
+    # pre-releases alike.
     unless os
-      tarball_files = Dir.glob("#{__dir__}/../output/openvoxdb-#{version}*.tar.gz")
+      base_version = version.split('~').first
+      tarball_files = Dir.glob("#{__dir__}/../output/openvoxdb-#{base_version}*.tar.gz")
       files = (files + tarball_files).uniq
     end
 


### PR DESCRIPTION
Follow-up to #254: same tarball-matching fix, but for pre-releases.

The tarball is globbed with the RPM version (`9.0.0~beta1`), but ezbake names it after the git tag (`9.0.0-beta1`), so beta/rc tarballs never matched and weren't uploaded (e.g. `.../openvoxdb/9.0.0~beta1/` only has RPMs/DEBs). Snapshots worked because there the version is already the plain base. Matching on the base version covers both.

I want to build OpenVox container images against the 9.0 betas and need the tarball; probably useful for the other OpenVox containers too.
