### PR TITLE
Add configuration options to filter facts out in OpenVoxDB termini

### DIFF
--- a/documentation/puppetdb_connection.markdown
+++ b/documentation/puppetdb_connection.markdown
@@ -114,3 +114,32 @@ When writing data (submitting commands) to OpenVoxDB, this is the minimum number
 The default value is one, which should be appropriate for most single- or dual-OpenVoxDB deployments.
 
 This setting must be used in conjunction with `command_broadcast`.
+
+### `fact_names_blocklist`
+
+This setting prevents selected facts from being sent to OpenVoxDB. It accepts a
+comma-separated list of exact fact paths. Top-level fact names can be listed
+directly, while keys in structured facts use dot notation:
+
+    fact_names_blocklist = secret, networking.interfaces.eth0.mac
+
+The example removes the complete `secret` fact and only the `mac` key below the
+`eth0` interface. Other keys in the `networking` structured fact are preserved.
+Array indexes are part of a structured path, so a path such as
+`disks.0.serial` identifies the `serial` key in the first `disks` element.
+
+The default value is an empty list, which sends all facts.
+
+### `fact_names_blocklist_regex`
+
+This setting accepts a comma-separated list of Ruby regular expressions. Each
+expression is matched against the complete dot-separated path of every fact key.
+For example, the following removes a `password` key at any nesting level,
+including from hashes contained in arrays:
+
+    fact_names_blocklist_regex = (^|\.)password$
+
+Regular expressions are validated when `puppetdb.conf` is loaded. Because commas
+separate entries in this setting, an expression cannot contain a comma.
+
+The default value is an empty list, which does not block any facts by pattern.

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -16,6 +16,49 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
     trusted.to_h
   end
 
+  # Return a copy of +value+ with every configured fact path removed. Paths use
+  # dot notation, so "networking.interfaces.eth0.mac" addresses a key nested
+  # inside a structured fact. Array indexes become path components while we
+  # descend (for example, "disks.0.serial"), which also lets regular expressions
+  # select identically named keys from every element of an array.
+  #
+  # Hashes and arrays are rebuilt instead of edited in place. The facts object is
+  # only shallow-copied by #save, and mutating a nested value here would otherwise
+  # also mutate the facts object owned by Puppet and visible to other terminuses.
+  def filter_facts(value, blocked_paths, blocked_path_regexps, path = [])
+    case value
+    when Hash
+      value.each_with_object({}) do |(key, nested_value), filtered|
+        nested_path = path + [key.to_s]
+        full_path = nested_path.join('.')
+        blocked = blocked_paths.include?(full_path) ||
+                  blocked_path_regexps.any? { |regexp| regexp.match(full_path) }
+
+        next if blocked
+
+        filtered[key] = filter_facts(
+          nested_value,
+          blocked_paths,
+          blocked_path_regexps,
+          nested_path
+        )
+      end
+    when Array
+      value.map.with_index do |nested_value, index|
+        # Array elements are retained to avoid changing the meaning of indexes.
+        # Their indexes are still included in paths for hashes below them.
+        filter_facts(
+          nested_value,
+          blocked_paths,
+          blocked_path_regexps,
+          path + [index.to_s]
+        )
+      end
+    else
+      value
+    end
+  end
+
   def save(request)
     profile("facts#save", [:puppetdb, :facts, :save, request.key]) do
       current_time = Time.now
@@ -30,6 +73,12 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           inventory = facts.values['_puppet_inventory_1']
           package_inventory = inventory['packages'] if inventory.respond_to?(:keys)
           facts.values.delete('_puppet_inventory_1')
+
+          blocked_paths = Puppet::Util::Puppetdb.config.fact_names_blocklist
+          blocked_path_regexps = Puppet::Util::Puppetdb.config.fact_names_blocklist_regex.map do |pattern|
+            Regexp.new(pattern)
+          end
+          facts.values = filter_facts(facts.values, blocked_paths, blocked_path_regexps)
 
           payload_value = {
             "certname" => facts.name,

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -70,15 +70,19 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           facts.values = facts.values.dup
           facts.values[:trusted] = get_trusted_info(request.node)
 
-          inventory = facts.values['_puppet_inventory_1']
-          package_inventory = inventory['packages'] if inventory.respond_to?(:keys)
-          facts.values.delete('_puppet_inventory_1')
-
+          # Filter the completed facts hash, including trusted data, before
+          # extracting package inventory. Since filter_facts rebuilds nested
+          # containers, values shared with Puppet's original facts stay intact.
           blocked_paths = Puppet::Util::Puppetdb.config.fact_names_blocklist
           blocked_path_regexps = Puppet::Util::Puppetdb.config.fact_names_blocklist_regex.map do |pattern|
             Regexp.new(pattern)
           end
           facts.values = filter_facts(facts.values, blocked_paths, blocked_path_regexps)
+
+          # Extract and remove inventory from the filtered copy in one step so
+          # blocklisting it, or its packages child, cannot bypass filtering.
+          inventory = facts.values.delete('_puppet_inventory_1')
+          package_inventory = inventory['packages'] if inventory.respond_to?(:keys)
 
           payload_value = {
             "certname" => facts.name,
@@ -91,7 +95,7 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
             "producer" => Puppet[:node_name_value]
           }
 
-          if inventory
+          if package_inventory
             payload_value['package_inventory'] = package_inventory
           end
 

--- a/puppet/lib/puppet/indirector/facts/puppetdb.rb
+++ b/puppet/lib/puppet/indirector/facts/puppetdb.rb
@@ -70,14 +70,20 @@ class Puppet::Node::Facts::Puppetdb < Puppet::Indirector::REST
           facts.values = facts.values.dup
           facts.values[:trusted] = get_trusted_info(request.node)
 
-          # Filter the completed facts hash, including trusted data, before
-          # extracting package inventory. Since filter_facts rebuilds nested
-          # containers, values shared with Puppet's original facts stay intact.
+          # Read the blocklists after adding trusted data so it can be filtered
+          # too. Filtering must happen before package inventory is extracted.
           blocked_paths = Puppet::Util::Puppetdb.config.fact_names_blocklist
-          blocked_path_regexps = Puppet::Util::Puppetdb.config.fact_names_blocklist_regex.map do |pattern|
-            Regexp.new(pattern)
+          blocked_path_patterns = Puppet::Util::Puppetdb.config.fact_names_blocklist_regex
+
+          # Preserve the usual shallow-copy path when filtering is disabled.
+          # When enabled, filter_facts rebuilds nested containers so values
+          # shared with Puppet's original facts stay intact.
+          unless blocked_paths.empty? && blocked_path_patterns.empty?
+            blocked_path_regexps = blocked_path_patterns.map do |pattern|
+              Regexp.new(pattern)
+            end
+            facts.values = filter_facts(facts.values, blocked_paths, blocked_path_regexps)
           end
-          facts.values = filter_facts(facts.values, blocked_paths, blocked_path_regexps)
 
           # Extract and remove inventory from the filtered copy in one step so
           # blocklisting it, or its packages child, cannot bypass filtering.

--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -18,7 +18,9 @@ module Puppet::Util::Puppetdb
         :submit_only_server_urls     => "",
         :command_broadcast           => false,
         :sticky_read_failover        => false,
-        :verify_client_certificate   => true
+        :verify_client_certificate   => true,
+        :fact_names_blocklist        => "",
+        :fact_names_blocklist_regex  => ""
       }
 
       config_file ||= File.join(Puppet[:confdir], "puppetdb.conf")
@@ -71,7 +73,9 @@ module Puppet::Util::Puppetdb
            :submit_only_server_urls,
            :command_broadcast,
            :sticky_read_failover,
-           :verify_client_certificate].include?(k))
+           :verify_client_certificate,
+           :fact_names_blocklist,
+           :fact_names_blocklist_regex].include?(k))
       end
 
       parsed_urls = config_hash[:server_urls].split(",").map {|s| s.strip}
@@ -87,6 +91,14 @@ module Puppet::Util::Puppetdb
       config_hash[:command_broadcast] = Puppet::Util::Puppetdb.to_bool(config_hash[:command_broadcast])
       config_hash[:sticky_read_failover] = Puppet::Util::Puppetdb.to_bool(config_hash[:sticky_read_failover])
       config_hash[:verify_client_certificate] = Puppet::Util::Puppetdb.to_bool(config_hash[:verify_client_certificate])
+
+      config_hash[:fact_names_blocklist] = config_hash[:fact_names_blocklist].split(",").map {|s| s.strip}
+      config_hash[:fact_names_blocklist_regex] = config_hash[:fact_names_blocklist_regex].split(",").map {|s| s.strip}
+
+      # Validate regular expressions while loading configuration rather than
+      # waiting for the first fact submission. This makes a typo fail at startup
+      # with the offending expression instead of breaking every agent command.
+      config_hash[:fact_names_blocklist_regex].each {|pattern| Regexp.new(pattern)}
 
       if config_hash[:soft_write_failure] and config_hash[:min_successful_submissions] > 1
         raise "soft_write_failure cannot be enabled when min_successful_submissions is greater than 1"
@@ -158,6 +170,14 @@ module Puppet::Util::Puppetdb
 
     def verify_client_certificate
       config[:verify_client_certificate]
+    end
+
+    def fact_names_blocklist
+      config[:fact_names_blocklist]
+    end
+
+    def fact_names_blocklist_regex
+      config[:fact_names_blocklist_regex]
     end
 
     # @!group Private instance methods

--- a/puppet/lib/puppet/util/puppetdb/config.rb
+++ b/puppet/lib/puppet/util/puppetdb/config.rb
@@ -92,8 +92,8 @@ module Puppet::Util::Puppetdb
       config_hash[:sticky_read_failover] = Puppet::Util::Puppetdb.to_bool(config_hash[:sticky_read_failover])
       config_hash[:verify_client_certificate] = Puppet::Util::Puppetdb.to_bool(config_hash[:verify_client_certificate])
 
-      config_hash[:fact_names_blocklist] = config_hash[:fact_names_blocklist].split(",").map {|s| s.strip}
-      config_hash[:fact_names_blocklist_regex] = config_hash[:fact_names_blocklist_regex].split(",").map {|s| s.strip}
+      config_hash[:fact_names_blocklist] = config_hash[:fact_names_blocklist].split(",").map {|s| s.strip}.reject(&:empty?)
+      config_hash[:fact_names_blocklist_regex] = config_hash[:fact_names_blocklist_regex].split(",").map {|s| s.strip}.reject(&:empty?)
 
       # Validate regular expressions while loading configuration rather than
       # waiting for the first fact submission. This makes a typo fail at startup

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -107,6 +107,55 @@ describe Puppet::Node::Facts::Puppetdb do
       end.returns responseok
       save
     end
+
+    it "should block exact and regular-expression paths in structured facts" do
+      Puppet::Util::Puppetdb.config.stubs(:fact_names_blocklist).returns [
+        'secret',
+        'networking.interfaces.eth0.mac'
+      ]
+      Puppet::Util::Puppetdb.config.stubs(:fact_names_blocklist_regex).returns [
+        '(^|\\.)password$'
+      ]
+
+      facts.values['secret'] = 'top-level secret'
+      facts.values['networking'] = {
+        'interfaces' => {
+          'eth0' => {'ip' => '192.0.2.10', 'mac' => '00:11:22:33:44:55'},
+          'eth1' => {'ip' => '192.0.2.11', 'mac' => '00:11:22:33:44:66'}
+        }
+      }
+      facts.values['accounts'] = [
+        {'name' => 'alice', 'password' => 'alice-secret'},
+        {'name' => 'bob', 'password' => 'bob-secret'}
+      ]
+
+      sent_payload = nil
+      http.expects(:post).with do |uri, body, headers|
+        sent_payload = body
+      end.returns responseok
+
+      save
+
+      submitted_facts = JSON.parse(sent_payload)['values']
+      submitted_facts.should_not have_key('secret')
+      submitted_facts['networking']['interfaces']['eth0'].should == {
+        'ip' => '192.0.2.10'
+      }
+      submitted_facts['networking']['interfaces']['eth1'].should == {
+        'ip' => '192.0.2.11',
+        'mac' => '00:11:22:33:44:66'
+      }
+      submitted_facts['accounts'].should == [
+        {'name' => 'alice'},
+        {'name' => 'bob'}
+      ]
+
+      # Filtering must not alter the Puppet-owned facts object, including any
+      # nested hashes or arrays shared by the shallow copy made in #save.
+      facts.values['secret'].should == 'top-level secret'
+      facts.values['networking']['interfaces']['eth0']['mac'].should == '00:11:22:33:44:55'
+      facts.values['accounts'][0]['password'].should == 'alice-secret'
+    end
   end
 
   describe "#get_trusted_info" do

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -98,6 +98,48 @@ describe Puppet::Node::Facts::Puppetdb do
       message['package_inventory'].should == [fact_tuple]
     end
 
+    it "should apply the blocklist before extracting package inventory" do
+      fact_tuple = ['openssl', '1.0.2g-1ubuntu4.6', 'apt']
+      inventory_fact_value = { 'packages' => [fact_tuple] }
+      Puppet::Util::Puppetdb.config.stubs(:fact_names_blocklist).returns [
+        '_puppet_inventory_1.packages'
+      ]
+
+      facts.values['_puppet_inventory_1'] = inventory_fact_value
+
+      sent_payload = nil
+      http.expects(:post).with do |uri, body, headers|
+        sent_payload = body
+      end.returns responseok
+      save
+      message = JSON.parse(sent_payload)
+
+      message['values'].should_not have_key('_puppet_inventory_1')
+      message.should_not have_key('package_inventory')
+
+      # Filtering must not alter the package inventory in the original facts.
+      facts.values['_puppet_inventory_1'].should == inventory_fact_value
+    end
+
+    it "should omit package inventory when its complete fact is blocklisted" do
+      fact_tuple = ['openssl', '1.0.2g-1ubuntu4.6', 'apt']
+      Puppet::Util::Puppetdb.config.stubs(:fact_names_blocklist).returns [
+        '_puppet_inventory_1'
+      ]
+
+      facts.values['_puppet_inventory_1'] = { 'packages' => [fact_tuple] }
+
+      sent_payload = nil
+      http.expects(:post).with do |uri, body, headers|
+        sent_payload = body
+      end.returns responseok
+      save
+      message = JSON.parse(sent_payload)
+
+      message['values'].should_not have_key('_puppet_inventory_1')
+      message.should_not have_key('package_inventory')
+    end
+
     it "shouldn't crash with a malformed inventory fact" do
       facts.values['_puppet_inventory_1'] = ['foo', 'bar']
 

--- a/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
+++ b/puppet/spec/unit/indirector/facts/puppetdb_spec.rb
@@ -78,6 +78,17 @@ describe Puppet::Node::Facts::Puppetdb do
       message['values']['something'].should == 100
     end
 
+    it "should not rebuild structured facts when both blocklists are empty" do
+      Puppet::Util::Puppetdb.config.stubs(:fact_names_blocklist).returns []
+      Puppet::Util::Puppetdb.config.stubs(:fact_names_blocklist_regex).returns []
+      subject.expects(:filter_facts).never
+
+      facts.values['structured'] = {'nested' => ['value']}
+
+      http.expects(:post).returns responseok
+      save
+    end
+
     it "should transform the package inventory fact when submitting" do
       fact_tuple = ['openssl', '1.0.2g-1ubuntu4.6', 'apt']
       inventory_fact_value = { 'packages' => [fact_tuple] }

--- a/puppet/spec/unit/util/puppetdb/config_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/config_spec.rb
@@ -26,6 +26,8 @@ describe Puppet::Util::Puppetdb::Config do
         config.server_urls.should == [URI("https://puppetdb:8081")]
         config.submit_only_server_urls.should == []
         config.min_successful_submissions.should == 1
+        config.fact_names_blocklist.should == []
+        config.fact_names_blocklist_regex.should == []
       end
 
     end
@@ -328,6 +330,35 @@ CONF
         config = described_class.load
         config.server_urls.should == [URI("https://foo.com"), URI("https://bar.com")]
         config.verify_client_certificate.should == false
+      end
+
+      it "should read fact name blocklists" do
+        write_config <<CONF
+[main]
+fact_names_blocklist = secret, networking.interfaces.eth0.mac
+fact_names_blocklist_regex = ^cloud\\., (^|\\.)password$
+CONF
+
+        config = described_class.load
+        config.fact_names_blocklist.should == [
+          'secret',
+          'networking.interfaces.eth0.mac'
+        ]
+        config.fact_names_blocklist_regex.should == [
+          '^cloud\\.',
+          '(^|\\.)password$'
+        ]
+      end
+
+      it "should reject an invalid fact name blocklist regular expression" do
+        write_config <<CONF
+[main]
+fact_names_blocklist_regex = [unterminated
+CONF
+
+        expect do
+          described_class.load
+        end.to raise_error(RegexpError, /unterminated/)
       end
 
     end

--- a/puppet/spec/unit/util/puppetdb/config_spec.rb
+++ b/puppet/spec/unit/util/puppetdb/config_spec.rb
@@ -350,6 +350,24 @@ CONF
         ]
       end
 
+      it "should ignore empty fact name blocklist entries" do
+        write_config <<CONF
+[main]
+fact_names_blocklist = , secret,, networking.interfaces.eth0.mac,
+fact_names_blocklist_regex = , ^cloud\\.,, (^|\\.)password$,
+CONF
+
+        config = described_class.load
+        config.fact_names_blocklist.should == [
+          'secret',
+          'networking.interfaces.eth0.mac'
+        ]
+        config.fact_names_blocklist_regex.should == [
+          '^cloud\\.',
+          '(^|\\.)password$'
+        ]
+      end
+
       it "should reject an invalid fact name blocklist regular expression" do
         write_config <<CONF
 [main]


### PR DESCRIPTION
  ## Summary

  Add two `puppetdb.conf` settings for excluding facts before they are submitted to OpenVoxDB:

  - `fact_names_blocklist` matches exact dot-separated fact paths.
  - `fact_names_blocklist_regex` matches complete fact paths using Ruby regular expressions.

  The filtering supports nested hashes and hashes inside arrays. It rebuilds structured values instead of modifying Puppet-owned facts in place.

  ## Motivation

  The existing server-side `facts-blocklist` setting cannot selectively remove keys from structured facts.

  This implements the behavior originally proposed in [puppetlabs/puppetdb#4021](https://github.com/puppetlabs/puppetdb/pull/4021), which is unlikely to be merged now that the upstream repository is inactive.

  ## Example

  ```ini
  [main]
  fact_names_blocklist = secret, networking.interfaces.eth0.mac
  fact_names_blocklist_regex = (^|\.)password$
  ```
  This removes:

  - The complete top-level secret fact.
  - Only networking.interfaces.eth0.mac from the structured networking fact.
  - Any key named password, including keys inside hashes contained in arrays.

  Invalid regular expressions are rejected when `puppetdb.conf` is loaded.

We have been using at CERN this as a `patch` for quite some time already and it covers our use cases such as blocking podman interfaces polluting OpenvoxDB:

```
cernpuppet::puppetdb::fact_names_blacklist_regex:
  - ^blockdevice_
  - ^db_
  # Migrating the filtering from https://github.com/cernops/facter/commit/6f7648b73dfe9fd35b9769eec0ac6053645d493a
  - ^networking.interfaces.*nic.*
  - ^networking.interfaces.*tap.*
  - ^networking.interfaces.veth.*
```

